### PR TITLE
Fix some bril-ocaml bugs

### DIFF
--- a/bril-ocaml/lib/func.ml
+++ b/bril-ocaml/lib/func.ml
@@ -204,7 +204,7 @@ module Dominance = struct
   end
 
   module Lists : S with type out := string list = struct
-    let f = Map.map ~f:String.Set.to_list
+    let f = Map.map ~f:Set.to_list
     let dominators ?strict = Fn.compose f (Sets.dominators ?strict)
     let dominated ?strict = Fn.compose f (Sets.dominated ?strict)
 

--- a/bril-ocaml/lib/instr.ml
+++ b/bril-ocaml/lib/instr.ml
@@ -236,7 +236,7 @@ let to_json =
     `Assoc
       [
         ("op", `String "ret");
-        ("args", Option.value_map arg ~default:`Null ~f:(fun arg -> `List [ `String arg ]));
+        ("args", Option.value_map arg ~default:(`List []) ~f:(fun arg -> `List [ `String arg ]));
       ]
   | Print args ->
     `Assoc [ ("op", `String "print"); ("args", `List (List.map args ~f:(fun arg -> `String arg))) ]
@@ -257,5 +257,5 @@ let to_json =
   | Alloc (dest, arg) -> build_op ~op:"alloc" ~args:[ arg ] ~dest ()
   | Free arg -> build_op ~op:"free" ~args:[ arg ] ()
   | Load (dest, arg) -> build_op ~op:"load" ~args:[ arg ] ~dest ()
-  | Store (arg1, arg2) -> build_op ~op:"load" ~args:[ arg1; arg2 ] ()
+  | Store (arg1, arg2) -> build_op ~op:"store" ~args:[ arg1; arg2 ] ()
   | PtrAdd (dest, arg1, arg2) -> build_op ~op:"ptradd" ~args:[ arg1; arg2 ] ~dest ()


### PR DESCRIPTION
1) In newer versions of Base it seems like `to_list` is no longer
   exposed on the specialized modules (e.g. `String.Set`)
2) The serialization of bril was broken. Specifically
   - Store was incorrectly serialized to load
   - An empty return was serialized to `{ args: null, ...}` instead of an empty list. This broke the Rust deserialization code. It is not clear to me which is broken -- the OCaml serialization code or the Rust deserialization code. The bril spec seems to disallow explicit null as args; it says that args is "optionally a list of arguments" which suggests that it should either not be present at all as a key or an empty list.